### PR TITLE
fsstresstest: Add missing system header for usleep.h

### DIFF
--- a/fsstresstest.c
+++ b/fsstresstest.c
@@ -32,6 +32,7 @@
 #include <getopt.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <unistd.h> /* usleep() */
 
 void fslog(char * format, ...)
 {


### PR DESCRIPTION
New compiler is strict and complains about the function declarations

Signed-off-by: Khem Raj <raj.khem@gmail.com>